### PR TITLE
Changed Classes.dex and ApkPatcher to use new CRC.

### DIFF
--- a/app/src/main/java/com/zane/smapiinstaller/logic/ApkPatcher.java
+++ b/app/src/main/java/com/zane/smapiinstaller/logic/ApkPatcher.java
@@ -281,7 +281,7 @@ public class ApkPatcher {
                         }
                     case "name":
                         if (strObj.contains(ManifestPatchConstants.PATTERN_MAIN_ACTIVITY)) {
-                            attr.obj = strObj.replaceFirst("\\w+\\.MainActivity", "md5723872fa9a204f7f942686e9ed9d0b7d.SMainActivity");
+                            attr.obj = strObj.replaceFirst("\\w+\\.MainActivity", "crc64a4555f9f70c213sd.SMainActivity");
                         }
                         break;
                     default:


### PR DESCRIPTION
Hi ZaneYork,

MartyrPher and Me have discovered some changes in the latest Stardew Valley version (1.4.5.151), the app changed from md5 hash to crc hash in the newer versions. 

We changed this hash in your installer and have included a new classes.dex reflecting these changes. 